### PR TITLE
Laravel 10 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [8.1, 8.0]
-        laravel: [9.*]
+        php: [8.2, 8.1]
+        laravel: [10.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 9.*
-            testbench: 7.*
+          - laravel: 10.*
+            testbench: 8.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/composer.json
+++ b/composer.json
@@ -5,12 +5,12 @@
     "type": "library",
     "license": "MIT",
     "require": {
-        "php": "^8.0",
-        "laravel/framework": "^9.0",
+        "php": "^8.1",
+        "laravel/framework": "^10.0",
         "ext-json": "*"
     },
     "require-dev": {
-        "orchestra/testbench": "^7.0"
+        "orchestra/testbench": "^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,23 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         backupGlobals="false"
          beStrictAboutTestsThatDoNotTestAnything="false"
          bootstrap="vendor/autoload.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
 >
     <testsuites>
         <testsuite name="Laraflash Test Suite">
-            <directory suffix=".php">./tests/</directory>
+            <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <coverage>
+        <include>
             <directory suffix=".php">./src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+  </coverage>
 </phpunit>

--- a/tests/ArrayMessagesStorageTest.php
+++ b/tests/ArrayMessagesStorageTest.php
@@ -5,7 +5,7 @@ namespace Coderello\Laraflash\Tests;
 use Coderello\Laraflash\MessagesStorage\ArrayMessagesStorage;
 use Coderello\Laraflash\Tests\Support\FlashMessageFactory;
 
-class ArrayMessagesStorageTest extends AbstractTestCase
+class ArrayMessagesStorageTest extends TestCase
 {
     /** @var ArrayMessagesStorage */
     protected $arrayMessagesStorage;

--- a/tests/FlashMessageFactoryTest.php
+++ b/tests/FlashMessageFactoryTest.php
@@ -5,7 +5,7 @@ namespace Coderello\Laraflash\Tests;
 use Coderello\Laraflash\FlashMessage\FlashMessage;
 use Coderello\Laraflash\FlashMessage\FlashMessageFactory;
 
-class FlashMessageFactoryTest extends AbstractTestCase
+class FlashMessageFactoryTest extends TestCase
 {
     /** @var FlashMessageFactory */
     protected $flashMessageFactory;

--- a/tests/FlashMessageTest.php
+++ b/tests/FlashMessageTest.php
@@ -7,7 +7,7 @@ use Coderello\Laraflash\Exceptions\InvalidHopsAmountException;
 use Coderello\Laraflash\FlashMessage\FlashMessage;
 use Illuminate\Support\Arr;
 
-class FlashMessageTest extends AbstractTestCase
+class FlashMessageTest extends TestCase
 {
     /** @var FlashMessage */
     protected $flashMessage;

--- a/tests/LaraflashPreparerTest.php
+++ b/tests/LaraflashPreparerTest.php
@@ -9,7 +9,7 @@ use Coderello\Laraflash\Tests\Support\LaraflashRenderer;
 use Coderello\Laraflash\Tests\Support\MessagesStorage;
 use Illuminate\Support\Facades\Request;
 
-class LaraflashPreparerTest extends AbstractTestCase
+class LaraflashPreparerTest extends TestCase
 {
     /** @var Laraflash */
     protected $laraflash;

--- a/tests/LaraflashRendererTest.php
+++ b/tests/LaraflashRendererTest.php
@@ -9,7 +9,7 @@ use Coderello\Laraflash\Tests\Support\FlashMessageRenderer;
 use Coderello\Laraflash\Tests\Support\MessagesStorage;
 use Illuminate\Config\Repository as ConfigRepository;
 
-class LaraflashRendererTest extends AbstractTestCase
+class LaraflashRendererTest extends TestCase
 {
     /** @var ConfigRepository */
     protected $configRepository;

--- a/tests/LaraflashTest.php
+++ b/tests/LaraflashTest.php
@@ -7,7 +7,7 @@ use Coderello\Laraflash\Tests\Support\FlashMessageFactory;
 use Coderello\Laraflash\Tests\Support\LaraflashRenderer;
 use Coderello\Laraflash\Tests\Support\MessagesStorage;
 
-class LaraflashTest extends AbstractTestCase
+class LaraflashTest extends TestCase
 {
     /** @var FlashMessageFactory */
     protected $flashMessageFactory;

--- a/tests/SessionMessagesStorageTest.php
+++ b/tests/SessionMessagesStorageTest.php
@@ -6,7 +6,7 @@ use Coderello\Laraflash\MessagesStorage\SessionMessagesStorage;
 use Coderello\Laraflash\Tests\Support\FlashMessageFactory;
 use Illuminate\Contracts\Session\Session;
 
-class SessionMessagesStorageTest extends AbstractTestCase
+class SessionMessagesStorageTest extends TestCase
 {
     /** @var Session */
     protected $session;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,7 +5,7 @@ namespace Coderello\Laraflash\Tests;
 use Coderello\Laraflash\Providers\LaraflashServiceProvider;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
 
-abstract class AbstractTestCase extends OrchestraTestCase
+class TestCase extends OrchestraTestCase
 {
     protected function getPackageProviders($app)
     {

--- a/tests/ViewFlashMessageRendererTest.php
+++ b/tests/ViewFlashMessageRendererTest.php
@@ -8,7 +8,7 @@ use Coderello\Laraflash\FlashMessage\ViewFlashMessageRenderer;
 use Coderello\Laraflash\Tests\Support\ViewFactory;
 use Illuminate\Config\Repository as ConfigRepository;
 
-class ViewFlashMessageRendererTest extends AbstractTestCase
+class ViewFlashMessageRendererTest extends TestCase
 {
     /** @var ConfigRepository */
     protected $configRepository;


### PR DESCRIPTION
Update to support Laravel 10. This mostly consists of changes to allow tests to run on PHPUnit 10 which is used by default in latest version Testbench.